### PR TITLE
1.1.0 Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,8 @@ rust-image = ["image"]
 bench = []
 
 [dependencies]
-algo = { git = "https://github.com/aleksandrpak/algo" }
 bit-vec = "*"
 rustc-serialize = "*"
-
 
 [dev-dependencies]
 rand = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ rust-image = ["image"]
 bench = []
 
 [dependencies]
+algo = { git = "https://github.com/aleksandrpak/algo" }
 bit-vec = "*"
 rustc-serialize = "*"
+
 
 [dev-dependencies]
 rand = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "img_hash"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 
 description = "A simple library that provides perceptual hashing and difference calculation for images."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,6 @@ bench = []
 bit-vec = "*"
 rustc-serialize = "*"
 
-[dependencies.stream-dct]
-version = "*"
-features = ["cos-approx"]
-
 [dev-dependencies]
 rand = "*"
 image = "*"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A library for getting perceptual hash values of images.
 Thanks to Dr. Neal Krawetz for the outlines of the Mean (aHash), Gradient (dHash), and DCT (pHash) perceptual hash algorithms:  
 http://www.hackerfactor.com/blog/?/archives/432-Looks-Like-It.html (Accessed August 2014)
 
+Also provides an implementation of [the Blockhash.io algorithm](https://blockhash.io).
+
 With the `rust-image` feature, this crate can operate directly on buffers from the [PistonDevelopers/image][1] crate.
 
 [1]: https://github.com/PistonDevelopers/image 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-img_hash [![Build Status](https://travis-ci.org/cybergeek94/img_hash.svg?branch=master)](https://travis-ci.org/cybergeek94/img_hash) [![Crates.io shield](https://img.shields.io/crates/v/img_hash.svg)](https://crates.io/crates/img_hash)
+img_hash [![Build Status](https://travis-ci.org/abonander/img_hash.svg?branch=master)](https://travis-ci.org/abonander/img_hash) [![Crates.io shield](https://img.shields.io/crates/v/img_hash.svg)](https://crates.io/crates/img_hash)
 ========
 
 ##### Now builds on stable Rust! (But needs nightly to bench.)
@@ -14,13 +14,13 @@ With the `rust-image` feature, this crate can operate directly on buffers from t
 
 Usage
 =====
-[Documentation on Rust-CI](http://rust-ci.org/cybergeek94/img_hash/doc/img_hash/index.html)
+[Documentation](https://docs.rs/img_hash)
 
 
 Add `img_hash` to your `Cargo.toml`:
 
     [dependencies.img_hash]
-    git = "https://github.com/cybergeek94/img_hash"
+    version = "1.1"
     # For interop with `image`:
     features = ["rust-image"]
     

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,0 +1,151 @@
+// Implementation of block-hashing as described here:
+// https://github.com/commonsmachinery/blockhash-rfc/blob/master/main.md#process-of-identifier-assignment
+// Main site: blockhash.io
+
+use super::HashImage;
+
+use bit_vec::BitVec;
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::iter;
+use std::ops::Mul;
+
+const FLOAT_EQ_MARGIN: f64 = 0.001;
+
+pub fn blockhash<I: HashImage>(img: &I, size: u32) -> BitVec {
+    let size = next_multiple_of_4(size);
+    let (width, height) = img.dimensions(); 
+
+    // Skip the floating point math if it's unnecessary
+    if width % size == 0 && height % size == 0 {
+        blockhash_fast(img, size)
+    } else {
+        blockhash_slow(img, size)
+    }        
+} 
+
+macro_rules! gen_hash {
+    ($imgty:ty, $valty:ty, $blocks: expr, $size:expr, $block_width:expr, $block_height:expr, $eq_fn:expr) => ({
+        let channel_count = <$imgty as HashImage>::channel_count() as u32;
+
+        let group_len = (($size * $size) / 4) as usize;
+
+        let block_area = $block_width * $block_height;
+
+        let cmp_factor = match channel_count {
+            3 | 4 => 255u32 as $valty * 3u32 as $valty,
+            2 | 1 => 255u32 as $valty,
+            _ => panic!("Unrecognized channel count from HashImage: {}", channel_count),
+        }  
+            * block_area 
+            / (2u32 as $valty);
+
+        let medians: Vec<$valty> = $blocks.chunks(group_len).map(get_median).collect();
+
+        $blocks.chunks(group_len).zip(medians)
+            .flat_map(|(blocks, median)| 
+                blocks.iter().map(move |&block| 
+                    block > median ||
+                        ($eq_fn(block, median) && median > cmp_factor)
+                )
+            )
+            .collect()
+    })
+}
+
+fn blockhash_slow<I: HashImage>(img: &I, size: u32) -> BitVec {
+    let mut blocks = vec![0f64; (size * size) as usize];
+
+    let (width, height) = img.dimensions();
+    
+    // Block dimensions, in pixels
+    let (block_width, block_height) = (width as f64 / size as f64, height as f64 / size as f64);
+
+    let idx = |x, y| (y * size + x) as usize;
+
+    img.foreach_pixel(|x, y, px| {
+        let px_sum = sum_px(px) as f64;
+
+        let (x, y) = (x as f64, y as f64);
+
+        let block_x = (x / block_width).floor();
+        let block_y = (y / block_height).floor();
+
+        let div_x = block_x * block_width;
+        let div_y = block_y * block_height;
+
+        let horz_overlap = div_x - x < 1.0;
+        let vert_overlap = div_y - y < 1.0;
+
+        // quadrant I
+        let area_a = div_x - x * div_y - y;
+        // quad II
+        let area_b = (x + 1.0 - div_x) * div_y - y;
+        // quad III
+        let area_c = div_x - x * (y + 1.0 - div_y);
+        // quad IV
+        let area_d = (x + 1.0 - div_x) * (y + 1.0 - div_y);
+
+        let block_x = block_x as u32;
+        let block_y = block_y as u32;
+
+        match (horz_overlap, vert_overlap) {
+            (true, true) => blocks[idx(block_x + 1, block_y +1)] += px_sum * area_d,
+            (true, _) => blocks[idx(block_x + 1, block_y)] += px_sum * area_b,
+            (_, true) => blocks[idx(block_x, block_y + 1)] += px_sum * area_c,
+            _ => (),
+        }
+
+        blocks[idx(block_x, block_y)] += px_sum * area_a;
+    });
+
+    
+    gen_hash!(I, f64, blocks, size, block_width, block_height, |l: f64, r: f64| l.abs_sub(r) < FLOAT_EQ_MARGIN)
+}
+
+fn blockhash_fast<I: HashImage>(img: &I, size: u32) -> BitVec {
+    let mut blocks = vec![0u32; (size * size) as usize];
+    let (width, height) = img.dimensions();
+
+    let (block_width, block_height) = (width / size, height / size);
+
+    let idx = |x, y| (y * size + x) as usize;
+
+    img.foreach_pixel(|x, y, px| { 
+        let px_sum = sum_px(px);
+
+        let block_x = x / block_width;
+        let block_y = y / block_width;
+
+        blocks[idx(block_x, block_y)] += px_sum;
+    });
+
+    gen_hash!(I, u32, blocks, size, block_width, block_height, |l, r| l == r)    
+}
+
+#[inline(always)]
+fn sum_px(px: &[u8]) -> u32 {
+    // Branch prediction should eliminate the match after a few iterations
+    match px.len() {
+        4 => if px[3] == 0 { 255 * 3 } else { sum_px(&px[..3]) },
+        3 => px[0] as u32 + px[1] as u32 + px[2] as u32,
+        2 => if px[1] == 0 { 255 } else { px[0] as u32 },
+        1 => px[0] as u32,
+        // We can only hit this assertion if there's a bug where the number of values
+        // per pixel doesn't match HashImage::channel_count
+        _ => panic!("Channel count was different than actual pixel size"),
+    }
+}
+
+// Get the next multiple of 4 up from x, or x if x is a multiple of 4
+fn next_multiple_of_4(x: u32) -> u32 {
+    x + 3 & !3
+}
+
+fn get_median<T>(blocks: &[T]) -> T where T: PartialOrd + Copy {
+    let mut blocks: Vec<&T> = blocks.iter().collect();
+    blocks.sort_by(|l, r| l.partial_cmp(r).unwrap_or(Ordering::Less));
+    *blocks[blocks.len() / 2]
+}
+

--- a/src/block.rs
+++ b/src/block.rs
@@ -4,12 +4,11 @@
 
 use super::HashImage;
 
+use algo::select;
+
 use bit_vec::BitVec;
 
 use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-use std::iter;
-use std::ops::Mul;
 
 const FLOAT_EQ_MARGIN: f64 = 0.001;
 
@@ -101,7 +100,8 @@ fn blockhash_slow<I: HashImage>(img: &I, size: u32) -> BitVec {
     });
 
     
-    gen_hash!(I, f64, blocks, size, block_width, block_height, |l: f64, r: f64| l.abs_sub(r) < FLOAT_EQ_MARGIN)
+    gen_hash!(I, f64, blocks, size, block_width, block_height,
+        |l: f64, r: f64| (l - r).abs() < FLOAT_EQ_MARGIN)
 }
 
 fn blockhash_fast<I: HashImage>(img: &I, size: u32) -> BitVec {
@@ -143,9 +143,6 @@ fn next_multiple_of_4(x: u32) -> u32 {
     x + 3 & !3
 }
 
-fn get_median<T>(blocks: &[T]) -> T where T: PartialOrd + Copy {
-    let mut blocks: Vec<&T> = blocks.iter().collect();
-    blocks.sort_by(|l, r| l.partial_cmp(r).unwrap_or(Ordering::Less));
-    *blocks[blocks.len() / 2]
+fn get_median<T: PartialOrd + Copy>(data: &[T]) -> T {
+    *select::median_by(data, |l, r| l.partial_cmp(r).unwrap_or(Ordering::Less))
 }
-

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -72,13 +72,23 @@ thread_local! {
 /// when performing multiple hashing runs with the same hash size, as compared to not performing
 /// this step.
 ///
-/// **Note:** Only affects the built-in DCT hash (`HashType::DCT`).
+/// ## Note
+/// This only affects the built-in DCT hash (`HashType::DCT`). It also includes
+/// the hash size multiplier applied by the DCT hash algorithm.
 ///
 /// ## Note: Thread-Local
 /// Because this uses thread-local storage, this will need to be called on every thread
 /// that will be using the DCT hash for the runtime benefit. You can also
 /// have precomputed matrices of different sizes for each thread.
 pub fn precompute_dct_matrix(size: u32) {
+    // The DCT hash uses a hash size larger than the user provided, so we have to
+    // precompute a matrix of the right size
+    let size = size * ::DCT_HASH_SIZE_MULTIPLIER;
+    precomp_exact(size);
+}
+
+/// Precompute a DCT matrix of the exact given size.
+pub fn precomp_exact(size: u32) {
     PRECOMPUTED_MATRIX.with(|matrix| precompute_matrix(size as usize, &mut matrix.borrow_mut()));
 }
 

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -74,7 +74,8 @@ thread_local! {
 ///
 /// ## Note
 /// This only affects the built-in DCT hash (`HashType::DCT`). It also includes
-/// the hash size multiplier applied by the DCT hash algorithm.
+/// the hash size multiplier applied by the DCT hash algorithm, so just pass the same
+/// hash size that you would to `ImageHash::hash()`.
 ///
 /// ## Note: Thread-Local
 /// Because this uses thread-local storage, this will need to be called on every thread

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -1,8 +1,7 @@
 use super::Columns;
 
-
 use std::f64::consts::{PI, SQRT_2};
-use std::ops::{Index, IndexMut, Range};
+use std::ops::{Index, IndexMut};
 
 struct ColumnsMut<'a, T: 'a> {
     data: &'a mut [T],

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -1,0 +1,179 @@
+use super::Columns;
+
+
+use std::f64::consts::{PI, SQRT_2};
+use std::ops::{Index, IndexMut, Range};
+
+struct ColumnsMut<'a, T: 'a> {
+    data: &'a mut [T],
+    rowstride: usize,
+    curr: usize,
+}
+
+impl<'a, T: 'a> ColumnsMut<'a, T> {
+    #[inline(always)]
+    fn from_slice(data: &'a mut [T], rowstride: usize) -> Self {
+        ColumnsMut {
+            data: data,
+            rowstride: rowstride,
+            curr: 0,
+        }
+    }
+}
+
+impl<'a, T: 'a> Iterator for ColumnsMut<'a, T> {
+    type Item = ColumnMut<'a, T>;
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.curr < self.rowstride {
+           let data = unsafe { &mut *(&mut self.data[self.curr..] as *mut [T]) };
+            self.curr += 1;
+            Some(ColumnMut {
+                data: data,
+                rowstride: self.rowstride,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+struct ColumnMut<'a, T: 'a> {
+    data: &'a mut [T],
+    rowstride: usize,
+}
+
+impl<'a, T: 'a> Index<usize> for ColumnMut<'a, T> {
+    type Output = T;
+    #[inline(always)]
+    fn index(&self, idx: usize) -> &T {
+       &self.data[idx * self.rowstride]
+    }
+}
+
+impl<'a, T: 'a> IndexMut<usize> for ColumnMut<'a, T> {
+    #[inline(always)]
+    fn index_mut(&mut self, idx: usize) -> &mut T {
+       &mut self.data[idx * self.rowstride]
+    }
+}
+
+pub fn dct_1d<I: Index<usize, Output=f64> + ?Sized, O: IndexMut<usize, Output=f64> + ?Sized>(input: &I, output: &mut O, len: usize) {
+    for i in 0 .. len {        
+        let mut z = 0.0;
+
+        for j in 0 .. len {
+            z += input[j] * (
+                PI * i as f64 * (2 * j + 1) as f64 
+                / (2 * len) as f64
+            ).cos();
+        } 
+
+        if i == 0 {
+            z *= 1.0 / SQRT_2;
+        }
+
+        output[i] = z / 2.0;
+    } 
+}
+
+/// Perform a 2D DCT on a 1D-packed vector with a given rowstride.
+///
+/// E.g. a vector of length 9 with a rowstride of 3 will be processed as a 3x3 matrix.
+///
+/// Returns a vector of the same size packed in the same way.
+pub fn dct_2d(packed_2d: &[f64], rowstride: usize) -> Vec<f64> {
+    assert_eq!(packed_2d.len() % rowstride, 0);
+
+    let mut scratch = Vec::with_capacity(packed_2d.len() * 2);
+    unsafe { scratch.set_len(packed_2d.len() * 2); }
+
+    {
+        let (col_pass, row_pass) = scratch.split_at_mut(packed_2d.len());
+    
+        for (row_in, row_out) in packed_2d.chunks(rowstride)
+                .zip(row_pass.chunks_mut(rowstride)) {                
+            dct_1d(row_in, row_out, rowstride);
+        }
+
+        for (col_in, mut col_out) in Columns::from_slice(row_pass, rowstride)
+                .zip(ColumnsMut::from_slice(col_pass, rowstride)) {
+            dct_1d(&col_in, &mut col_out, rowstride);
+        }
+    }
+
+    scratch.truncate(packed_2d.len());
+    scratch
+}
+
+/*
+#[cfg(feature = "simd")]
+mod dct_simd {
+    use simdty::f64x2;
+
+    use std::f64::consts::{PI, SQRT_2};
+    
+    macro_rules! valx2 ( ($val:expr) => ( ::simdty::f64x2($val, $val) ) );
+
+    const PI: f64x2 = valx2!(PI);
+    const ONE_DIV_SQRT_2: f64x2 = valx2!(1 / SQRT_2);
+    const SQRT_2: f64x2 = valx2!(SQRT_2);
+
+    pub dct_rows(vals: &[Vec<f64>]) -> Vec<Vec<f64>> {
+        let mut out = Vec::with_capacity(vals.len());
+
+        for pair in vals.iter().chunks(2) {
+            if pair.len() == 2 {
+                let vals = pair[0].iter().cloned().zip(pair[1].iter().cloned())
+                    .map(f64x2)
+                    .collect();
+
+                dct_1dx2(vals);
+
+
+        
+        }
+    }
+
+    fn dct_1dx2(vec: Vec<f64x2>) -> Vec<f64x2> {
+        let mut out = Vec::with_capacity(vec.len());
+
+        for u in 0 .. vec.len() {
+            let mut z = valx2!(0.0);
+
+            for x in 0 .. vec.len() {
+                z += vec[x] * cos_approx(
+                    PI * valx2!(
+                        u as f64 * (2 * x + 1) as f64 
+                            / (2 * vec.len()) as f64
+                    )
+                );
+            }
+
+            if u == 0 {
+                z *= ONE_DIV_SQRT_2;
+            }
+
+            out.insert(u, z / valx2!(2.0));
+        }
+
+        out 
+    }
+
+    fn cos_approx(x2: f64x2) -> f64x2 {
+        #[inline(always)]
+        fn powi(val: f64x2, pow: i32) -> f64x2 {
+            unsafe { llvmint::powi_v2f64(val, pow) }
+        }
+
+        let x2 = powi(val, 2);
+        let x4 = powi(val, 4);
+        let x6 = powi(val, 6);
+        let x8 = powi(val, 8);
+
+        valx2!(1.0) - (x2 / valx2!(2.0)) + (x4 / valx2!(24.0)) 
+            - (x6 / valx2!(720.0)) + (x8 / valx2!(40320.0))
+    }
+}
+*/
+

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -65,11 +65,14 @@ thread_local! {
 /// Precompute the DCT matrix for a given hash size and memoize it in thread-local
 /// storage.
 ///
+///
 /// If a precomputed matrix was already stored, even of the same length, it will be overwritten.
 ///
 /// This can produce a significant runtime savings (an order of magnitude on the author's machine)
-/// when performing multiple hashing runs with the same hash, as compared to not performing this
-/// step.
+/// when performing multiple hashing runs with the same hash size, as compared to not performing
+/// this step.
+///
+/// **Note:** Only affects the built-in DCT hash (`HashType::DCT`).
 ///
 /// ## Note: Thread-Local
 /// Because this uses thread-local storage, this will need to be called on every thread

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,9 +225,12 @@ pub enum HashType {
     /// This algorithm first averages the pixels of the reduced-size and color image,
     /// and then compares each pixel to the average.
     ///
-    /// Fastest, but inaccurate. Really only useful for finding duplicates.
+    /// Fast, but inaccurate. Really only useful for finding duplicates.
     Mean,
-    /// Blockhash.io algorithm
+    /// The [Blockhash.io](https://blockhash.io) algorithm.
+    ///
+    /// Faster than `Mean` but also prone to more collisions and suitable only for finding
+    /// duplicates.
     Block,
     /// This algorithm compares each pixel in a row to its neighbor and registers changes in
     /// gradients (e.g. edges and color boundaries).
@@ -243,6 +246,9 @@ pub enum HashType {
     /// then compares each datapoint in the transform to the average.
     ///
     /// Slowest by far, but can detect changes in color gamut and sometimes relatively significant edits.
+    ///
+    /// Call `precompute_dct_matrix()` with your chosen hash size to memoize the DCT matrix for the
+    /// given size, which can produce significant speedups in repeated hash runs.
     DCT,
     /// Equivalent to `DCT`, but allows the user to provide their own 2-dimensional DCT function. 
     /// See the `DCT2DFunc` docs for more info.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@
 // Silence feature warnings for test module.
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 
+extern crate algo;
+
 extern crate bit_vec;
 
 #[cfg(any(test, feature = "rust-image"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,8 @@ pub enum HashType {
     ///
     /// Fastest, but inaccurate. Really only useful for finding duplicates.
     Mean,
+    /// Blockhash.io algorithm
+    Block,
     /// This algorithm compares each pixel in a row to its neighbor and registers changes in
     /// gradients (e.g. edges and color boundaries).
     ///
@@ -253,6 +255,7 @@ impl HashType {
 
         match self {
             Mean => mean_hash(img, hash_size),
+            Block => block::blockhash(img, hash_size),
             DCT => dct_hash(img, hash_size, DCT2DFunc(dct_2d)),
             Gradient => gradient_hash(img, hash_size),
             DoubleGradient => double_gradient_hash(img, hash_size),
@@ -265,6 +268,7 @@ impl HashType {
 
         match self {
             Mean => 1,
+            Block => 6,
             DCT => 2,
             Gradient => 3,
             DoubleGradient => 4,
@@ -281,6 +285,7 @@ impl HashType {
             3 => Gradient,
             4 => DoubleGradient,
             5 => UserDCT(DCT2DFunc(dct_2d)),
+            6 => Block,
             _ => panic!("Byte {:?} cannot be coerced to a `HashType`!", byte),
         }
     }
@@ -567,6 +572,7 @@ mod test {
         bench_hash! { bench_gradient_hash : HashType::Gradient }
         bench_hash! { bench_dbl_gradient_hash : HashType::DoubleGradient }
         bench_hash! { bench_dct_hash : HashType::DCT }
+        bench_hash! { bench_block_hash: HashType::Block }
 
         #[bench]
         fn bench_dct_1d(b: &mut Bencher) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,6 @@
 // Silence feature warnings for test module.
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 
-extern crate algo;
-
 extern crate bit_vec;
 
 #[cfg(any(test, feature = "rust-image"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! }
 //! ```
 //! [1]: https://github.com/PistonDevelopers/image
+#![deny(missing_docs)]
 // Silence feature warnings for test module.
 #![cfg_attr(all(test, feature = "bench"), feature(test))]
 
@@ -65,6 +66,7 @@ pub use dct::precompute_dct_matrix;
 pub struct ImageHash {
     /// The bits of the hash
     pub bitv: BitVec,
+    /// The type of the hash
     pub hash_type: HashType,
 }
 
@@ -418,19 +420,30 @@ fn double_gradient_hash<I: HashImage>(img: &I, hash_size: u32) -> BitVec {
 ///
 /// Implement this for custom image types.
 pub trait HashImage {
+    /// The image type when converted to grayscale.
     type Grayscale: HashImage;
 
+    /// The dimensions of the image as (width, height).
     fn dimensions(&self) -> (u32, u32);
 
     /// Returns a copy, leaving `self` unmodified.
     fn resize(&self, width: u32, height: u32) -> Self;
 
+    /// Convert `self` to grayscale.
     fn grayscale(&self) -> Self::Grayscale;
 
+    /// Convert `self` to a byte-vector.
     fn to_bytes(self) -> Vec<u8>;
 
+    /// Get the number of pixel channels in the image:
+    ///
+    /// * 1 -> Grayscale
+    /// * 2 -> Grayscale with Alpha
+    /// * 3 -> RGB
+    /// * 4 -> RGB with Alpha
     fn channel_count() -> u8;
 
+    /// Call `iter_fn` for each pixel in the image, passing `(x, y, [pixel data])`.
     fn foreach_pixel<F>(&self, iter_fn: F) where F: FnMut(u32, u32, &[u8]);
 }
 

--- a/src/rust_image.rs
+++ b/src/rust_image.rs
@@ -10,21 +10,21 @@ use image::{
     Pixel
 };
 
-use super::{HashImage, LumaBytes};
+use super::HashImage;
 
 const FILTER_TYPE: FilterType = FilterType::Nearest;
 
 macro_rules! hash_img_impl {
-    ($ty:ty ($lumaty:ty)) => (
+    ($ty:ident ($lumaty:ty)) => (
         impl HashImage for $ty {
             type Grayscale = $lumaty;
 
             fn dimensions(&self) -> (u32, u32) {
-                <Self as GenericImage>::dimensions(self) 
+                self.dimensions()
             }
 
             fn resize(&self, width: u32, height: u32) -> Self {
-                imageops::resize(self, width, height, FILTER_TYPE);
+                imageops::resize(self, width, height, FILTER_TYPE)
             }
 
             fn grayscale(&self) -> $lumaty {
@@ -39,18 +39,47 @@ macro_rules! hash_img_impl {
                 <<Self as GenericImage>::Pixel as Pixel>::channel_count()
             }
 
-            fn foreach_pixel(&self, mut iter_fn: F) where F: (u32, u32, &[u8]) {
-                for (x, y, px) in self.pixels() {
+            fn foreach_pixel<F>(&self, mut iter_fn: F) where F: FnMut(u32, u32, &[u8]) {
+                for (x, y, px) in self.enumerate_pixels() {
                     iter_fn(x, y, px.channels());
                 }
             }
         }
     );
-    ($($ty:ty ($lumaty:ty)),+) => ( $(hash_img_impl! { $ty($lumaty) })+ );
+    ($($ty:ident ($lumaty:ty)),+) => ( $(hash_img_impl! { $ty($lumaty) })+ );
 }
 
 hash_img_impl! { 
     GrayImage(GrayImage), GrayAlphaImage(GrayImage), 
-    RgbImage(GrayImage), RgbaImage(GrayImage), 
-    DynamicImage(GrayImage)
+    RgbImage(GrayImage), RgbaImage(GrayImage) 
 }
+
+impl HashImage for DynamicImage {
+            type Grayscale = GrayImage;
+
+            fn dimensions(&self) -> (u32, u32) {
+                <Self as GenericImage>::dimensions(self) 
+            }
+
+            fn resize(&self, width: u32, height: u32) -> Self {
+                self.resize(width, height, FILTER_TYPE)
+            }
+
+            fn grayscale(&self) -> GrayImage {
+                imageops::grayscale(self)
+            }
+
+            fn to_bytes(self) -> Vec<u8> {
+                self.raw_pixels()
+            }
+
+            fn channel_count() -> u8 {
+                <<Self as GenericImage>::Pixel as Pixel>::channel_count()
+            }
+
+            fn foreach_pixel<F>(&self, mut iter_fn: F) where F: FnMut(u32, u32, &[u8]) {
+                for (x, y, px) in self.pixels() {
+                    iter_fn(x, y, px.channels());
+                }
+            }
+        }

--- a/src/rust_image.rs
+++ b/src/rust_image.rs
@@ -15,9 +15,9 @@ const FILTER_TYPE: FilterType = FilterType::Nearest;
 macro_rules! hash_img_impl {
     ($ty:ty) => (
         impl HashImage for $ty {
-            fn to_hashable(&self, size: u32) -> LumaBytes {
+            fn to_hashable(&self, width: u32, height: u32) -> LumaBytes {
                 let ref gray = imageops::grayscale(self);
-                let resized = imageops::resize(gray, size, size, FILTER_TYPE);
+                let resized = imageops::resize(gray, width, height, FILTER_TYPE);
                 resized.into_raw()
             }
         }

--- a/src/rust_image.rs
+++ b/src/rust_image.rs
@@ -6,6 +6,8 @@ use image::{
     GrayAlphaImage,
     RgbImage,
     RgbaImage,
+    GenericImage,
+    Pixel
 };
 
 use super::{HashImage, LumaBytes};
@@ -13,16 +15,42 @@ use super::{HashImage, LumaBytes};
 const FILTER_TYPE: FilterType = FilterType::Nearest;
 
 macro_rules! hash_img_impl {
-    ($ty:ty) => (
+    ($ty:ty ($lumaty:ty)) => (
         impl HashImage for $ty {
-            fn to_hashable(&self, width: u32, height: u32) -> LumaBytes {
-                let ref gray = imageops::grayscale(self);
-                let resized = imageops::resize(gray, width, height, FILTER_TYPE);
-                resized.into_raw()
+            type Grayscale = $lumaty;
+
+            fn dimensions(&self) -> (u32, u32) {
+                <Self as GenericImage>::dimensions(self) 
+            }
+
+            fn resize(&self, width: u32, height: u32) -> Self {
+                imageops::resize(self, width, height, FILTER_TYPE);
+            }
+
+            fn grayscale(&self) -> $lumaty {
+                imageops::grayscale(self)
+            }
+
+            fn to_bytes(self) -> Vec<u8> {
+                self.into_raw()
+            }
+
+            fn channel_count() -> u8 {
+                <<Self as GenericImage>::Pixel as Pixel>::channel_count()
+            }
+
+            fn foreach_pixel(&self, mut iter_fn: F) where F: (u32, u32, &[u8]) {
+                for (x, y, px) in self.pixels() {
+                    iter_fn(x, y, px.channels());
+                }
             }
         }
     );
-    ($($ty:ty),+) => ( $(hash_img_impl! { $ty })+ );
+    ($($ty:ty ($lumaty:ty)),+) => ( $(hash_img_impl! { $ty($lumaty) })+ );
 }
 
-hash_img_impl! { GrayImage, GrayAlphaImage, RgbImage, RgbaImage, DynamicImage }
+hash_img_impl! { 
+    GrayImage(GrayImage), GrayAlphaImage(GrayImage), 
+    RgbImage(GrayImage), RgbaImage(GrayImage), 
+    DynamicImage(GrayImage)
+}


### PR DESCRIPTION
* Add [Blockhash.io](https://blockhash.io) algorithm, faster than `Mean` but considered less accurate:
```
test test::bench::bench_block_hash        ... bench:      38,487 ns/iter (+/- 1,141)
test test::bench::bench_mean_hash         ... bench:      41,279 ns/iter (+/- 205)
```
* Add `precompute_dct_matrix()` which memoizes the DCT matrix for a given hash size and can produce significant speedups in successive hash runs (an order of magnitude on my machine):

```
test test::bench::bench_dct_1d            ... bench:         874 ns/iter (+/- 19)
test test::bench::bench_dct_1d_precomp    ... bench:          66 ns/iter (+/- 0)
test test::bench::bench_dct_2d            ... bench:      14,134 ns/iter (+/- 270)
test test::bench::bench_dct_2d_precomp    ... bench:       1,144 ns/iter (+/- 10)
test test::bench::bench_dct_hash          ... bench:   1,124,094 ns/iter (+/- 22,839)
test test::bench::bench_dct_hash_precomp  ... bench:     181,993 ns/iter (+/- 1,252)
```

* Remove some `unsafe` code that wasn't strictly necessary

* Drop `stream_dct` as a dependency

* Minor documentation improvements

RFC: this PR introduces breaking changes but I've only incremented the minor version in Semver. Time to go to 2.0, or yank 1.0 and drop down to 0.6?