### PR TITLE
Port to image 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ rust-image = ["image"]
 bench = []
 
 [dependencies]
-bit-vec = "0.4"
+bit-vec = "0.5"
 rustc-serialize = "0.3"
 
 [dev-dependencies]
-rand = "0.3"
-image = ">=0.10, <=0.19"
+rand = "0.6"
+image = "0.21"
 
 [dependencies.image]
-version = ">=0.10, <=0.19"
+version = "0.21"
 optional = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,7 +499,8 @@ mod test {
 
     use image::{Rgba, ImageBuffer};
 
-    use self::rand::{weak_rng, Rng};
+    use self::rand::{FromEntropy, RngCore};
+    use self::rand::rngs::SmallRng;
 
     use super::{DCT2DFunc, HashType, ImageHash};
 
@@ -509,7 +510,8 @@ mod test {
         let len = (width * height * 4) as usize;
         let mut buf = Vec::with_capacity(len);
         unsafe { buf.set_len(len); } // We immediately fill the buffer.
-        weak_rng().fill_bytes(&mut *buf);
+        let mut small_rng = SmallRng::from_entropy();
+        small_rng.fill_bytes(&mut *buf);
 
         ImageBuffer::from_raw(width, height, buf).unwrap()
     }

--- a/src/rust_image.rs
+++ b/src/rust_image.rs
@@ -13,7 +13,7 @@ use image::{
     GrayAlphaImage,
     RgbImage,
     RgbaImage,
-    GenericImage,
+    GenericImageView,
     Pixel
 };
 
@@ -43,7 +43,7 @@ macro_rules! hash_img_impl {
             }
 
             fn channel_count() -> u8 {
-                <<Self as GenericImage>::Pixel as Pixel>::channel_count()
+                <<Self as GenericImageView>::Pixel as Pixel>::channel_count()
             }
 
             fn foreach_pixel<F>(&self, mut iter_fn: F) where F: FnMut(u32, u32, &[u8]) {
@@ -65,7 +65,7 @@ impl HashImage for DynamicImage {
             type Grayscale = GrayImage;
 
             fn dimensions(&self) -> (u32, u32) {
-                <Self as GenericImage>::dimensions(self) 
+                <Self as GenericImageView>::dimensions(self)
             }
 
             fn resize(&self, width: u32, height: u32) -> Self {
@@ -81,7 +81,7 @@ impl HashImage for DynamicImage {
             }
 
             fn channel_count() -> u8 {
-                <<Self as GenericImage>::Pixel as Pixel>::channel_count()
+                <<Self as GenericImageView>::Pixel as Pixel>::channel_count()
             }
 
             fn foreach_pixel<F>(&self, mut iter_fn: F) where F: FnMut(u32, u32, &[u8]) {


### PR DESCRIPTION
This allows img_hash to be used by projects that depend on image 0.21. Sadly 0.20 is breaking so this change isn't reverse compatible and would require a semver bump.

This patch is relevant for me because I depend on another crate that requires image 0.21 and as far as I can tell this is the only way to use both at once.

Thanks!