### PR TITLE
Freshen crate, fix to/from_base64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-image = ["image"]
 bench = []
 
 [dependencies]
-bit-vec = "0.4"
+bit-vec = "0.6"
 rustc-serialize = "0.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,9 @@ bit-vec = "0.4"
 rustc-serialize = "0.3"
 
 [dev-dependencies]
-rand = "0.3"
-image = ">=0.10, <=0.19"
+image = "0.22.2"
 
 [dependencies.image]
-version = ">=0.10, <=0.19"
+version = "0.22.2"
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bit-vec = "0.4"
 rustc-serialize = "0.3"
 
 [dev-dependencies]
+rand = { version = "0.7", features = ["small_rng"] }
 image = "0.22.2"
 
 [dependencies.image]

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -21,8 +21,8 @@ impl<'a, T: 'a> ColumnsMut<'a, T> {
     #[inline(always)]
     fn from_slice(data: &'a mut [T], rowstride: usize) -> Self {
         ColumnsMut {
-            data: data,
-            rowstride: rowstride,
+            data,
+            rowstride,
             curr: 0,
         }
     }
@@ -36,7 +36,7 @@ impl<'a, T: 'a> Iterator for ColumnsMut<'a, T> {
            let data = unsafe { &mut *(&mut self.data[self.curr..] as *mut [T]) };
             self.curr += 1;
             Some(ColumnMut {
-                data: data,
+                data,
                 rowstride: self.rowstride,
             })
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,7 +518,7 @@ mod test {
 
     use image::{ImageBuffer, Rgba};
 
-    use self::rand::{weak_rng, Rng};
+    use self::rand::{rngs::SmallRng, RngCore, SeedableRng};
 
     use super::{DCT2DFunc, HashType, ImageHash};
 
@@ -531,6 +531,7 @@ mod test {
             buf.set_len(len);
         } // We immediately fill the buffer.
 
+        SmallRng::from_entropy().fill_bytes(&mut *buf);
 
         ImageBuffer::from_raw(width, height, buf).unwrap()
     }

--- a/src/rust_image.rs
+++ b/src/rust_image.rs
@@ -13,7 +13,7 @@ use image::{
     GrayAlphaImage,
     RgbImage,
     RgbaImage,
-    GenericImage,
+    GenericImageView,
     Pixel
 };
 
@@ -43,7 +43,7 @@ macro_rules! hash_img_impl {
             }
 
             fn channel_count() -> u8 {
-                <<Self as GenericImage>::Pixel as Pixel>::channel_count()
+                <<Self as GenericImageView>::Pixel as Pixel>::CHANNEL_COUNT
             }
 
             fn foreach_pixel<F>(&self, mut iter_fn: F) where F: FnMut(u32, u32, &[u8]) {
@@ -62,31 +62,31 @@ hash_img_impl! {
 }
 
 impl HashImage for DynamicImage {
-            type Grayscale = GrayImage;
+    type Grayscale = GrayImage;
 
-            fn dimensions(&self) -> (u32, u32) {
-                <Self as GenericImage>::dimensions(self) 
-            }
+    fn dimensions(&self) -> (u32, u32) {
+        <Self as GenericImageView>::dimensions(self) 
+    }
 
-            fn resize(&self, width: u32, height: u32) -> Self {
-                self.resize(width, height, FILTER_TYPE)
-            }
+    fn resize(&self, width: u32, height: u32) -> Self {
+        self.resize(width, height, FILTER_TYPE)
+    }
 
-            fn grayscale(&self) -> GrayImage {
-                imageops::grayscale(self)
-            }
+    fn grayscale(&self) -> GrayImage {
+        imageops::grayscale(self)
+    }
 
-            fn to_bytes(self) -> Vec<u8> {
-                self.raw_pixels()
-            }
+    fn to_bytes(self) -> Vec<u8> {
+        self.raw_pixels()
+    }
 
-            fn channel_count() -> u8 {
-                <<Self as GenericImage>::Pixel as Pixel>::channel_count()
-            }
+    fn channel_count() -> u8 {
+        <<Self as GenericImageView>::Pixel as Pixel>::CHANNEL_COUNT
+    }
 
-            fn foreach_pixel<F>(&self, mut iter_fn: F) where F: FnMut(u32, u32, &[u8]) {
-                for (x, y, px) in self.pixels() {
-                    iter_fn(x, y, px.channels());
-                }
-            }
+    fn foreach_pixel<F>(&self, mut iter_fn: F) where F: FnMut(u32, u32, &[u8]) {
+        for (x, y, px) in self.pixels() {
+            iter_fn(x, y, px.channels());
         }
+    }
+}

--- a/src/rust_image.rs
+++ b/src/rust_image.rs
@@ -6,15 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use image::{
-    imageops,
-    DynamicImage,
-    FilterType,
-    GrayImage,
-    GrayAlphaImage,
-    RgbImage,
-    RgbaImage,
-    GenericImageView,
-    Pixel
+    imageops, DynamicImage, FilterType, GenericImageView, GrayAlphaImage, GrayImage, Pixel,
+    RgbImage, RgbaImage,
 };
 
 use super::HashImage;
@@ -56,16 +49,16 @@ macro_rules! hash_img_impl {
     ($($ty:ident ($lumaty:ty)),+) => ( $(hash_img_impl! { $ty($lumaty) })+ );
 }
 
-hash_img_impl! { 
-    GrayImage(GrayImage), GrayAlphaImage(GrayImage), 
-    RgbImage(GrayImage), RgbaImage(GrayImage) 
+hash_img_impl! {
+    GrayImage(GrayImage), GrayAlphaImage(GrayImage),
+    RgbImage(GrayImage), RgbaImage(GrayImage)
 }
 
 impl HashImage for DynamicImage {
     type Grayscale = GrayImage;
 
     fn dimensions(&self) -> (u32, u32) {
-        <Self as GenericImageView>::dimensions(self) 
+        <Self as GenericImageView>::dimensions(self)
     }
 
     fn resize(&self, width: u32, height: u32) -> Self {
@@ -84,7 +77,10 @@ impl HashImage for DynamicImage {
         <<Self as GenericImageView>::Pixel as Pixel>::CHANNEL_COUNT
     }
 
-    fn foreach_pixel<F>(&self, mut iter_fn: F) where F: FnMut(u32, u32, &[u8]) {
+    fn foreach_pixel<F>(&self, mut iter_fn: F)
+    where
+        F: FnMut(u32, u32, &[u8]),
+    {
         for (x, y, px) in self.pixels() {
             iter_fn(x, y, px.channels());
         }


### PR DESCRIPTION
This change went further than initially expected, feel free to ask me to split it up into smaller PRs if you want!

* [FIX](https://github.com/abonander/img_hash/commit/27075899e96e221c5f3515e388fb5706a3bee31f): Bitvec's to_bytes pads bits to the next byte, the test wasn't catching that this was a problem because the number of bits for the hash were divisible by 8, this just adds the number of padding bits into the top bits of the header byte that was being used for the HasherType so that the bitvec has the correct length after deserialization.
* Add support for the latest version of `image` (0.22.2) - Fairly minor update
* Bump `rand` to `0.7.0` - Only used by tests, so figured this was fine
* Rustformatted and fixed all the clippy lints