### PR TITLE
Remove unnecessary indirect dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ nightly = []
 
 [dependencies]
 base64 = ">=0.10,<0.12"
-image = ">=0.21,<0.24"
+image = { version = ">=0.21,<0.24", default-features = false }
 rustdct = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 transpose = "0.2"


### PR DESCRIPTION
This deactivates all unnecessary features of the image dependency. The image dependency usually pulls in a lot of indirect dependencies that you possibly don't want.

In particular this causes issues in my case, because it pulls in rayon, which doesn't work in WebAssembly.