### PR TITLE
binary: Format without dropping zeros

### DIFF
--- a/src/bin/hash_image.rs
+++ b/src/bin/hash_image.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), String> {
 
     let hash = HasherConfig::new().hash_size(8, 8).to_hasher().hash_image(&image);
 
-    let hash_str = hash.as_bytes().iter().map(|b| format!("{:X}", b)).collect::<String>();
+    let hash_str = hash.as_bytes().iter().map(|b| format!("{:02x}", b)).collect::<String>();
 
     println!("{}: {}", &args[1], hash_str);
 


### PR DESCRIPTION
The hex string formatting of hash_image binary (which is the only
example of hex-formatting in the code base) used to elide leading zeros,
which makes the resulting hashes hard to compare against other
implementations' output values, and can be confusing when trying to
understand the resulting hash's size.

Casing is set to lower-case hex as that appears to be more common in
other hash implementations.